### PR TITLE
Bug Fix - Context Label not always set as a string

### DIFF
--- a/p-isa_tools/kerngen/high_parser/parser.py
+++ b/p-isa_tools/kerngen/high_parser/parser.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 """Module for parsing isa commands"""
@@ -68,7 +68,7 @@ class ParseResults:
         if Config.legacy_mode is True:
             for command in commands:
                 if isinstance(command, HighOp) and hasattr(command, "context"):
-                    command.context.label = self.context.ntt_stages
+                    command.context.label = str(self.context.ntt_stages)
 
         return (
             command.to_pisa() if isinstance(command, HighOp) else None

--- a/p-isa_tools/kerngen/kernel_parser/parser.py
+++ b/p-isa_tools/kerngen/kernel_parser/parser.py
@@ -54,7 +54,7 @@ class KernelParser:
                 current_rns=int(context_match.group("current_rns")),
                 max_rns=int(context_match.group("key_rns")) - 1,
             ),
-            label=context_match.group("label"),
+            label=str(context_match.group("label")),
         )
 
     @staticmethod


### PR DESCRIPTION
## Proposed changes

- Bug fix - under legacy mode, the context label was set as an integer and not a string. The fix forces the type to always be a str.

## Types of changes

What types of changes does your code introduce to the Encrypted Computing SDK project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you are unsure about any of them, do not hesitate to ask. We are
here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/IntelLabs/encrypted-computing-sdk/blob/main/CONTRIBUTING.md) agreement
- [x] Current formatting and unit tests / base functionality passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

NA
