### PR TITLE
New Feature: Adds support for composed kernel reordering for Mod Switch

### DIFF
--- a/p-isa_tools/kerngen/pisa_generators/mod.py
+++ b/p-isa_tools/kerngen/pisa_generators/mod.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 """Module containing conversions or operations from isa to p-isa."""
@@ -89,7 +89,7 @@ class Mod(HighOp):
                 stages.append(
                     Stage(
                         [
-                            Comment("Mod Stage 1"),
+                            Comment("Mod Stage 1 <reorderable>"),
                             muli_last_half(
                                 self.context,
                                 temp_input_remaining_rns,
@@ -194,7 +194,7 @@ class Mod(HighOp):
             + stages[2].pisa_ops
             + [
                 Muli(self.context, self.output, temp_input_remaining_rns, iq),
-                Comment("End of mod kernel"),
+                Comment("End of mod kernel </reorderable>"),
             ]
         )
 


### PR DESCRIPTION
## Proposed changes

- Adds Mod switch to Kerngraph for RNS/Part reordering
- Uses `<reorderable>` tag in comment to indicate which part of the kernel is reorderable.
- Add intt to kerngraph

## Types of changes

What types of changes does your code introduce to the Encrypted Computing SDK project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you are unsure about any of them, do not hesitate to ask. We are
here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/IntelLabs/encrypted-computing-sdk/blob/main/CONTRIBUTING.md) agreement
- [x] Current formatting and unit tests / base functionality passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Sample Usage and Output

1. Mod Switch with primary loop = part, secondary loop = part
```
$ cat bgv.mod.high | ./kerngen.py -l | ./kerngraph.py -l -t mod -p part
14, intt, outtmp_0_1_0, outtmp_0_1_1, input_0_1_0, input_0_1_1, w_1_0_0, 1
14, intt, y_0_1_0, y_0_1_1, outtmp_0_1_0, outtmp_0_1_1, w_1_1_0, 1
14, intt, outtmp_0_1_0, outtmp_0_1_1, y_0_1_0, y_0_1_1, w_1_2_0, 1
14, intt, y_0_1_0, y_0_1_1, outtmp_0_1_0, outtmp_0_1_1, w_1_3_0, 1
14, intt, outtmp_0_1_0, outtmp_0_1_1, y_0_1_0, y_0_1_1, w_1_4_0, 1
14, intt, y_0_1_0, y_0_1_1, outtmp_0_1_0, outtmp_0_1_1, w_1_5_0, 1
14, intt, outtmp_0_1_0, outtmp_0_1_1, y_0_1_0, y_0_1_1, w_1_6_0, 1
14, intt, y_0_1_0, y_0_1_1, outtmp_0_1_0, outtmp_0_1_1, w_1_7_0, 1
14, intt, outtmp_0_1_0, outtmp_0_1_1, y_0_1_0, y_0_1_1, w_1_8_0, 1
14, intt, y_0_1_0, y_0_1_1, outtmp_0_1_0, outtmp_0_1_1, w_1_9_0, 1
14, intt, outtmp_0_1_0, outtmp_0_1_1, y_0_1_0, y_0_1_1, w_1_10_0, 1
14, intt, y_0_1_0, y_0_1_1, outtmp_0_1_0, outtmp_0_1_1, w_1_11_0, 1
14, intt, outtmp_0_1_0, outtmp_0_1_1, y_0_1_0, y_0_1_1, w_1_12_0, 1
14, intt, y_0_1_0, y_0_1_1, outtmp_0_1_0, outtmp_0_1_1, w_1_13_0, 1
14, intt, outtmp_1_1_0, outtmp_1_1_1, input_1_1_0, input_1_1_1, w_1_0_0, 1
14, intt, y_1_1_0, y_1_1_1, outtmp_1_1_0, outtmp_1_1_1, w_1_1_0, 1
14, intt, outtmp_1_1_0, outtmp_1_1_1, y_1_1_0, y_1_1_1, w_1_2_0, 1
14, intt, y_1_1_0, y_1_1_1, outtmp_1_1_0, outtmp_1_1_1, w_1_3_0, 1
14, intt, outtmp_1_1_0, outtmp_1_1_1, y_1_1_0, y_1_1_1, w_1_4_0, 1
14, intt, y_1_1_0, y_1_1_1, outtmp_1_1_0, outtmp_1_1_1, w_1_5_0, 1
14, intt, outtmp_1_1_0, outtmp_1_1_1, y_1_1_0, y_1_1_1, w_1_6_0, 1
14, intt, y_1_1_0, y_1_1_1, outtmp_1_1_0, outtmp_1_1_1, w_1_7_0, 1
14, intt, outtmp_1_1_0, outtmp_1_1_1, y_1_1_0, y_1_1_1, w_1_8_0, 1
14, intt, y_1_1_0, y_1_1_1, outtmp_1_1_0, outtmp_1_1_1, w_1_9_0, 1
14, intt, outtmp_1_1_0, outtmp_1_1_1, y_1_1_0, y_1_1_1, w_1_10_0, 1
14, intt, y_1_1_0, y_1_1_1, outtmp_1_1_0, outtmp_1_1_1, w_1_11_0, 1
14, intt, outtmp_1_1_0, outtmp_1_1_1, y_1_1_0, y_1_1_1, w_1_12_0, 1
14, intt, y_1_1_0, y_1_1_1, outtmp_1_1_0, outtmp_1_1_1, w_1_13_0, 1
14, mul, y_0_1_0, y_0_1_0, ipsi_0_1_0, 1
14, mul, y_1_1_0, y_1_1_0, ipsi_0_1_0, 1
14, mul, y_0_1_1, y_0_1_1, ipsi_0_1_1, 1
14, mul, y_1_1_1, y_1_1_1, ipsi_0_1_1, 1
14, muli, y_0_1_0, y_0_1_0, iN, 1
14, muli, y_1_1_0, y_1_1_0, iN, 1
14, muli, y_0_1_1, y_0_1_1, iN, 1
14, muli, y_1_1_1, y_1_1_1, iN, 1
14, muli, y_0_1_0, y_0_1_0, it_mod_qLast_2, 1
14, muli, y_1_1_0, y_1_1_0, it_mod_qLast_2, 1
14, muli, y_0_1_1, y_0_1_1, it_mod_qLast_2, 1
14, muli, y_1_1_1, y_1_1_1, it_mod_qLast_2, 1
14, muli, y_0_1_0, y_0_1_0, one, 1
14, muli, y_1_1_0, y_1_1_0, one, 1
14, muli, y_0_1_1, y_0_1_1, one, 1
14, muli, y_1_1_1, y_1_1_1, one, 1
14, muli, x_0_0_0, y_0_1_0, R2_0, 0
14, muli, x_0_0_1, y_0_1_1, R2_0, 0
14, mul, x_0_0_0, x_0_0_0, psi_0_0_0, 0
14, mul, x_0_0_1, x_0_0_1, psi_0_0_1, 0
14, ntt, outtmp_0_0_0, outtmp_0_0_1, x_0_0_0, x_0_0_1, w_0_0_0, 0
14, ntt, x_0_0_0, x_0_0_1, outtmp_0_0_0, outtmp_0_0_1, w_0_1_0, 0
14, ntt, outtmp_0_0_0, outtmp_0_0_1, x_0_0_0, x_0_0_1, w_0_2_0, 0
14, ntt, x_0_0_0, x_0_0_1, outtmp_0_0_0, outtmp_0_0_1, w_0_3_0, 0
14, ntt, outtmp_0_0_0, outtmp_0_0_1, x_0_0_0, x_0_0_1, w_0_4_0, 0
14, ntt, x_0_0_0, x_0_0_1, outtmp_0_0_0, outtmp_0_0_1, w_0_5_0, 0
14, ntt, outtmp_0_0_0, outtmp_0_0_1, x_0_0_0, x_0_0_1, w_0_6_0, 0
14, ntt, x_0_0_0, x_0_0_1, outtmp_0_0_0, outtmp_0_0_1, w_0_7_0, 0
14, ntt, outtmp_0_0_0, outtmp_0_0_1, x_0_0_0, x_0_0_1, w_0_8_0, 0
14, ntt, x_0_0_0, x_0_0_1, outtmp_0_0_0, outtmp_0_0_1, w_0_9_0, 0
14, ntt, outtmp_0_0_0, outtmp_0_0_1, x_0_0_0, x_0_0_1, w_0_10_0, 0
14, ntt, x_0_0_0, x_0_0_1, outtmp_0_0_0, outtmp_0_0_1, w_0_11_0, 0
14, ntt, outtmp_0_0_0, outtmp_0_0_1, x_0_0_0, x_0_0_1, w_0_12_0, 0
14, ntt, x_0_0_0, x_0_0_1, outtmp_0_0_0, outtmp_0_0_1, w_0_13_0, 0
14, muli, x_0_0_0, x_0_0_0, t_0, 0
14, muli, x_0_0_1, x_0_0_1, t_0, 0
14, add, x_0_0_0, x_0_0_0, input_0_0_0, 0
14, add, x_0_0_1, x_0_0_1, input_0_0_1, 0
14, muli, output_0_0_0, x_0_0_0, iq_mod_qLast_2_0, 0
14, muli, output_0_0_1, x_0_0_1, iq_mod_qLast_2_0, 0
14, muli, x_1_0_0, y_1_1_0, R2_0, 0
14, muli, x_1_0_1, y_1_1_1, R2_0, 0
14, mul, x_1_0_0, x_1_0_0, psi_0_0_0, 0
14, mul, x_1_0_1, x_1_0_1, psi_0_0_1, 0
14, ntt, outtmp_1_0_0, outtmp_1_0_1, x_1_0_0, x_1_0_1, w_0_0_0, 0
14, ntt, x_1_0_0, x_1_0_1, outtmp_1_0_0, outtmp_1_0_1, w_0_1_0, 0
14, ntt, outtmp_1_0_0, outtmp_1_0_1, x_1_0_0, x_1_0_1, w_0_2_0, 0
14, ntt, x_1_0_0, x_1_0_1, outtmp_1_0_0, outtmp_1_0_1, w_0_3_0, 0
14, ntt, outtmp_1_0_0, outtmp_1_0_1, x_1_0_0, x_1_0_1, w_0_4_0, 0
14, ntt, x_1_0_0, x_1_0_1, outtmp_1_0_0, outtmp_1_0_1, w_0_5_0, 0
14, ntt, outtmp_1_0_0, outtmp_1_0_1, x_1_0_0, x_1_0_1, w_0_6_0, 0
14, ntt, x_1_0_0, x_1_0_1, outtmp_1_0_0, outtmp_1_0_1, w_0_7_0, 0
14, ntt, outtmp_1_0_0, outtmp_1_0_1, x_1_0_0, x_1_0_1, w_0_8_0, 0
14, ntt, x_1_0_0, x_1_0_1, outtmp_1_0_0, outtmp_1_0_1, w_0_9_0, 0
14, ntt, outtmp_1_0_0, outtmp_1_0_1, x_1_0_0, x_1_0_1, w_0_10_0, 0
14, ntt, x_1_0_0, x_1_0_1, outtmp_1_0_0, outtmp_1_0_1, w_0_11_0, 0
14, ntt, outtmp_1_0_0, outtmp_1_0_1, x_1_0_0, x_1_0_1, w_0_12_0, 0
14, ntt, x_1_0_0, x_1_0_1, outtmp_1_0_0, outtmp_1_0_1, w_0_13_0, 0
14, muli, x_1_0_0, x_1_0_0, t_0, 0
14, muli, x_1_0_1, x_1_0_1, t_0, 0
14, add, x_1_0_0, x_1_0_0, input_1_0_0, 0
14, add, x_1_0_1, x_1_0_1, input_1_0_1, 0
14, muli, output_1_0_0, x_1_0_0, iq_mod_qLast_2_0, 0
14, muli, output_1_0_1, x_1_0_1, iq_mod_qLast_2_0, 0
```


2. Mod Switch with primary loop = rns
```
$ cat bgv.mod.high | ./kerngen.py -l | ./kerngraph.py -l -t mod -p rns 
14, intt, outtmp_0_1_0, outtmp_0_1_1, input_0_1_0, input_0_1_1, w_1_0_0, 1
14, intt, y_0_1_0, y_0_1_1, outtmp_0_1_0, outtmp_0_1_1, w_1_1_0, 1
14, intt, outtmp_0_1_0, outtmp_0_1_1, y_0_1_0, y_0_1_1, w_1_2_0, 1
14, intt, y_0_1_0, y_0_1_1, outtmp_0_1_0, outtmp_0_1_1, w_1_3_0, 1
14, intt, outtmp_0_1_0, outtmp_0_1_1, y_0_1_0, y_0_1_1, w_1_4_0, 1
14, intt, y_0_1_0, y_0_1_1, outtmp_0_1_0, outtmp_0_1_1, w_1_5_0, 1
14, intt, outtmp_0_1_0, outtmp_0_1_1, y_0_1_0, y_0_1_1, w_1_6_0, 1
14, intt, y_0_1_0, y_0_1_1, outtmp_0_1_0, outtmp_0_1_1, w_1_7_0, 1
14, intt, outtmp_0_1_0, outtmp_0_1_1, y_0_1_0, y_0_1_1, w_1_8_0, 1
14, intt, y_0_1_0, y_0_1_1, outtmp_0_1_0, outtmp_0_1_1, w_1_9_0, 1
14, intt, outtmp_0_1_0, outtmp_0_1_1, y_0_1_0, y_0_1_1, w_1_10_0, 1
14, intt, y_0_1_0, y_0_1_1, outtmp_0_1_0, outtmp_0_1_1, w_1_11_0, 1
14, intt, outtmp_0_1_0, outtmp_0_1_1, y_0_1_0, y_0_1_1, w_1_12_0, 1
14, intt, y_0_1_0, y_0_1_1, outtmp_0_1_0, outtmp_0_1_1, w_1_13_0, 1
14, intt, outtmp_1_1_0, outtmp_1_1_1, input_1_1_0, input_1_1_1, w_1_0_0, 1
14, intt, y_1_1_0, y_1_1_1, outtmp_1_1_0, outtmp_1_1_1, w_1_1_0, 1
14, intt, outtmp_1_1_0, outtmp_1_1_1, y_1_1_0, y_1_1_1, w_1_2_0, 1
14, intt, y_1_1_0, y_1_1_1, outtmp_1_1_0, outtmp_1_1_1, w_1_3_0, 1
14, intt, outtmp_1_1_0, outtmp_1_1_1, y_1_1_0, y_1_1_1, w_1_4_0, 1
14, intt, y_1_1_0, y_1_1_1, outtmp_1_1_0, outtmp_1_1_1, w_1_5_0, 1
14, intt, outtmp_1_1_0, outtmp_1_1_1, y_1_1_0, y_1_1_1, w_1_6_0, 1
14, intt, y_1_1_0, y_1_1_1, outtmp_1_1_0, outtmp_1_1_1, w_1_7_0, 1
14, intt, outtmp_1_1_0, outtmp_1_1_1, y_1_1_0, y_1_1_1, w_1_8_0, 1
14, intt, y_1_1_0, y_1_1_1, outtmp_1_1_0, outtmp_1_1_1, w_1_9_0, 1
14, intt, outtmp_1_1_0, outtmp_1_1_1, y_1_1_0, y_1_1_1, w_1_10_0, 1
14, intt, y_1_1_0, y_1_1_1, outtmp_1_1_0, outtmp_1_1_1, w_1_11_0, 1
14, intt, outtmp_1_1_0, outtmp_1_1_1, y_1_1_0, y_1_1_1, w_1_12_0, 1
14, intt, y_1_1_0, y_1_1_1, outtmp_1_1_0, outtmp_1_1_1, w_1_13_0, 1
14, mul, y_0_1_0, y_0_1_0, ipsi_0_1_0, 1
14, mul, y_1_1_0, y_1_1_0, ipsi_0_1_0, 1
14, mul, y_0_1_1, y_0_1_1, ipsi_0_1_1, 1
14, mul, y_1_1_1, y_1_1_1, ipsi_0_1_1, 1
14, muli, y_0_1_0, y_0_1_0, iN, 1
14, muli, y_1_1_0, y_1_1_0, iN, 1
14, muli, y_0_1_1, y_0_1_1, iN, 1
14, muli, y_1_1_1, y_1_1_1, iN, 1
14, muli, y_0_1_0, y_0_1_0, it_mod_qLast_2, 1
14, muli, y_1_1_0, y_1_1_0, it_mod_qLast_2, 1
14, muli, y_0_1_1, y_0_1_1, it_mod_qLast_2, 1
14, muli, y_1_1_1, y_1_1_1, it_mod_qLast_2, 1
14, muli, y_0_1_0, y_0_1_0, one, 1
14, muli, y_1_1_0, y_1_1_0, one, 1
14, muli, y_0_1_1, y_0_1_1, one, 1
14, muli, y_1_1_1, y_1_1_1, one, 1
14, muli, x_0_0_0, y_0_1_0, R2_0, 0
14, muli, x_0_0_1, y_0_1_1, R2_0, 0
14, muli, x_1_0_0, y_1_1_0, R2_0, 0
14, muli, x_1_0_1, y_1_1_1, R2_0, 0
14, mul, x_0_0_0, x_0_0_0, psi_0_0_0, 0
14, mul, x_1_0_0, x_1_0_0, psi_0_0_0, 0
14, mul, x_0_0_1, x_0_0_1, psi_0_0_1, 0
14, mul, x_1_0_1, x_1_0_1, psi_0_0_1, 0
14, ntt, outtmp_0_0_0, outtmp_0_0_1, x_0_0_0, x_0_0_1, w_0_0_0, 0
14, ntt, x_0_0_0, x_0_0_1, outtmp_0_0_0, outtmp_0_0_1, w_0_1_0, 0
14, ntt, outtmp_0_0_0, outtmp_0_0_1, x_0_0_0, x_0_0_1, w_0_2_0, 0
14, ntt, x_0_0_0, x_0_0_1, outtmp_0_0_0, outtmp_0_0_1, w_0_3_0, 0
14, ntt, outtmp_0_0_0, outtmp_0_0_1, x_0_0_0, x_0_0_1, w_0_4_0, 0
14, ntt, x_0_0_0, x_0_0_1, outtmp_0_0_0, outtmp_0_0_1, w_0_5_0, 0
14, ntt, outtmp_0_0_0, outtmp_0_0_1, x_0_0_0, x_0_0_1, w_0_6_0, 0
14, ntt, x_0_0_0, x_0_0_1, outtmp_0_0_0, outtmp_0_0_1, w_0_7_0, 0
14, ntt, outtmp_0_0_0, outtmp_0_0_1, x_0_0_0, x_0_0_1, w_0_8_0, 0
14, ntt, x_0_0_0, x_0_0_1, outtmp_0_0_0, outtmp_0_0_1, w_0_9_0, 0
14, ntt, outtmp_0_0_0, outtmp_0_0_1, x_0_0_0, x_0_0_1, w_0_10_0, 0
14, ntt, x_0_0_0, x_0_0_1, outtmp_0_0_0, outtmp_0_0_1, w_0_11_0, 0
14, ntt, outtmp_0_0_0, outtmp_0_0_1, x_0_0_0, x_0_0_1, w_0_12_0, 0
14, ntt, x_0_0_0, x_0_0_1, outtmp_0_0_0, outtmp_0_0_1, w_0_13_0, 0
14, ntt, outtmp_1_0_0, outtmp_1_0_1, x_1_0_0, x_1_0_1, w_0_0_0, 0
14, ntt, x_1_0_0, x_1_0_1, outtmp_1_0_0, outtmp_1_0_1, w_0_1_0, 0
14, ntt, outtmp_1_0_0, outtmp_1_0_1, x_1_0_0, x_1_0_1, w_0_2_0, 0
14, ntt, x_1_0_0, x_1_0_1, outtmp_1_0_0, outtmp_1_0_1, w_0_3_0, 0
14, ntt, outtmp_1_0_0, outtmp_1_0_1, x_1_0_0, x_1_0_1, w_0_4_0, 0
14, ntt, x_1_0_0, x_1_0_1, outtmp_1_0_0, outtmp_1_0_1, w_0_5_0, 0
14, ntt, outtmp_1_0_0, outtmp_1_0_1, x_1_0_0, x_1_0_1, w_0_6_0, 0
14, ntt, x_1_0_0, x_1_0_1, outtmp_1_0_0, outtmp_1_0_1, w_0_7_0, 0
14, ntt, outtmp_1_0_0, outtmp_1_0_1, x_1_0_0, x_1_0_1, w_0_8_0, 0
14, ntt, x_1_0_0, x_1_0_1, outtmp_1_0_0, outtmp_1_0_1, w_0_9_0, 0
14, ntt, outtmp_1_0_0, outtmp_1_0_1, x_1_0_0, x_1_0_1, w_0_10_0, 0
14, ntt, x_1_0_0, x_1_0_1, outtmp_1_0_0, outtmp_1_0_1, w_0_11_0, 0
14, ntt, outtmp_1_0_0, outtmp_1_0_1, x_1_0_0, x_1_0_1, w_0_12_0, 0
14, ntt, x_1_0_0, x_1_0_1, outtmp_1_0_0, outtmp_1_0_1, w_0_13_0, 0
14, muli, x_0_0_0, x_0_0_0, t_0, 0
14, muli, x_1_0_0, x_1_0_0, t_0, 0
14, muli, x_0_0_1, x_0_0_1, t_0, 0
14, muli, x_1_0_1, x_1_0_1, t_0, 0
14, add, x_0_0_0, x_0_0_0, input_0_0_0, 0
14, add, x_0_0_1, x_0_0_1, input_0_0_1, 0
14, add, x_1_0_0, x_1_0_0, input_1_0_0, 0
14, add, x_1_0_1, x_1_0_1, input_1_0_1, 0
14, muli, output_0_0_0, x_0_0_0, iq_mod_qLast_2_0, 0
14, muli, output_1_0_0, x_1_0_0, iq_mod_qLast_2_0, 0
14, muli, output_0_0_1, x_0_0_1, iq_mod_qLast_2_0, 0
14, muli, output_1_0_1, x_1_0_1, iq_mod_qLast_2_0, 0
```