### PR TITLE
Bug Fix: Sub Kernel issue with input0/1 ordering.

### DIFF
--- a/p-isa_tools/kerngen/pisa_generators/basic.py
+++ b/p-isa_tools/kerngen/pisa_generators/basic.py
@@ -69,14 +69,18 @@ class CartesianOp(HighOp):
         # Not the same number of parts
         first, second = (self.input0, self.input1) if self.input0.parts < self.input1.parts else (self.input1, self.input0)
 
+        # Preserve the ordering of the inputs (output = input0 op input1) to avoid issues with non-commutative ops (e.g. sub)
+        # For example input0 - input1 != input1 - input0
+        order_preserved = first == self.input0
+
         ls: list[PIsaOp] = []
         for unit, q in it.product(range(self.context.units), range(self.input0.start_rns, self.input0.rns)):
             ls.extend(
                 self.op(
                     self.context.label,
                     self.output(part, q, unit),
-                    first(part, q, unit),
-                    second(0, q, unit),
+                    first(part, q, unit) if order_preserved else second(0, q, unit),
+                    second(0, q, unit) if order_preserved else first(part, q, unit),
                     q,
                 )
                 for part in range(first.parts)


### PR DESCRIPTION

## Proposed changes

Bug fixes an issue in CartesianOp which assumes ops are commutative. When inputs have mismatching parts, input1/0 were swapped, which only works for Add, not Sub. The fix maintains the ordering of inputs regardless of size of parts. 

## Types of changes

What types of changes does your code introduce to the Encrypted Computing SDK project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you are unsure about any of them, do not hesitate to ask. We are
here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/IntelLabs/encrypted-computing-sdk/blob/main/CONTRIBUTING.md) agreement
- [x] Current formatting and unit tests / base functionality passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

NA
