### PR TITLE
Bug fix  - Kerngen crash large RNS values.

### DIFF
--- a/p-isa_tools/kerngen/pisa_generators/basic.py
+++ b/p-isa_tools/kerngen/pisa_generators/basic.py
@@ -6,7 +6,6 @@
 import itertools as it
 from collections.abc import Iterable
 from dataclasses import dataclass
-from string import ascii_letters
 from typing import ClassVar
 
 import high_parser.pisa_operations as pisa_op
@@ -244,7 +243,7 @@ class KeyMul(HighOp):
         ls: list[pisa_op] = []
         for digit, op in get_pisa_op(self.input1.digits):
             input0_tmp = Polys.from_polys(self.input0)
-            input0_tmp.name += "_" + ascii_letters[digit]
+            input0_tmp.name += f"_{digit}"
 
             # mul/mac for 0-current_rns
             ls.extend(

--- a/p-isa_tools/kerngen/pisa_generators/decomp.py
+++ b/p-isa_tools/kerngen/pisa_generators/decomp.py
@@ -4,7 +4,6 @@
 
 import itertools as it
 from dataclasses import dataclass
-from string import ascii_letters
 
 import high_parser.pisa_operations as pisa_op
 from high_parser import HighOp, Immediate, KernelContext, Polys
@@ -66,7 +65,7 @@ class DigitDecompExtend(HighOp):
             )
 
             output_tmp = Polys.from_polys(self.output)
-            output_tmp.name += "_" + ascii_letters[input_rns_index]
+            output_tmp.name += f"_{input_rns_index}"
             output_split = Polys.from_polys(self.output)
             output_split.rns = self.context.current_rns
             # ntt for 0-current_rns

--- a/p-isa_tools/kerngen/tests/kernel_examples/relin_kernel/output.bgv.16k_l2_m3.relin
+++ b/p-isa_tools/kerngen/tests/kernel_examples/relin_kernel/output.bgv.16k_l2_m3.relin
@@ -44,132 +44,132 @@
 0, muli, coeffs_2_1_1, ct_2_0_1, R2_1, 1
 0, muli, coeffs_2_2_0, ct_2_0_0, R2_2, 2
 0, muli, coeffs_2_2_1, ct_2_0_1, R2_2, 2
-0, mul, coeffs_a_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
-0, mul, coeffs_a_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
-0, mul, coeffs_a_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
-0, mul, coeffs_a_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, 0, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, 0, 0, 1
-0, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 1, 0, 0
-0, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 1, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, 2, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, 2, 0, 1
-0, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 3, 0, 0
-0, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 3, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, 4, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, 4, 0, 1
-0, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 5, 0, 0
-0, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 5, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, 6, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, 6, 0, 1
-0, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 7, 0, 0
-0, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 7, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, 8, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, 8, 0, 1
-0, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 9, 0, 0
-0, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 9, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, 10, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, 10, 0, 1
-0, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 11, 0, 0
-0, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 11, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, 12, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, 12, 0, 1
-0, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 13, 0, 0
-0, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 13, 0, 1
-0, mul, coeffs_a_2_2_0, coeffs_2_2_0, psi_0_2_0, 2
-0, mul, coeffs_a_2_2_1, coeffs_2_2_1, psi_0_2_1, 2
-0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_a_2_2_0, coeffs_a_2_2_1, 0, 0, 2
-0, ntt, coeffs_a_2_2_0, coeffs_a_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 1, 0, 2
-0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_a_2_2_0, coeffs_a_2_2_1, 2, 0, 2
-0, ntt, coeffs_a_2_2_0, coeffs_a_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 3, 0, 2
-0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_a_2_2_0, coeffs_a_2_2_1, 4, 0, 2
-0, ntt, coeffs_a_2_2_0, coeffs_a_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 5, 0, 2
-0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_a_2_2_0, coeffs_a_2_2_1, 6, 0, 2
-0, ntt, coeffs_a_2_2_0, coeffs_a_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 7, 0, 2
-0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_a_2_2_0, coeffs_a_2_2_1, 8, 0, 2
-0, ntt, coeffs_a_2_2_0, coeffs_a_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 9, 0, 2
-0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_a_2_2_0, coeffs_a_2_2_1, 10, 0, 2
-0, ntt, coeffs_a_2_2_0, coeffs_a_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 11, 0, 2
-0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_a_2_2_0, coeffs_a_2_2_1, 12, 0, 2
-0, ntt, coeffs_a_2_2_0, coeffs_a_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 13, 0, 2
+0, mul, coeffs_0_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
+0, mul, coeffs_0_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
+0, mul, coeffs_0_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
+0, mul, coeffs_0_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, 0, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, 0, 0, 1
+0, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 1, 0, 0
+0, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 1, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, 2, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, 2, 0, 1
+0, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 3, 0, 0
+0, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 3, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, 4, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, 4, 0, 1
+0, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 5, 0, 0
+0, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 5, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, 6, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, 6, 0, 1
+0, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 7, 0, 0
+0, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 7, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, 8, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, 8, 0, 1
+0, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 9, 0, 0
+0, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 9, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, 10, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, 10, 0, 1
+0, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 11, 0, 0
+0, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 11, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, 12, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, 12, 0, 1
+0, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 13, 0, 0
+0, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 13, 0, 1
+0, mul, coeffs_0_2_2_0, coeffs_2_2_0, psi_0_2_0, 2
+0, mul, coeffs_0_2_2_1, coeffs_2_2_1, psi_0_2_1, 2
+0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_0_2_2_0, coeffs_0_2_2_1, 0, 0, 2
+0, ntt, coeffs_0_2_2_0, coeffs_0_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 1, 0, 2
+0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_0_2_2_0, coeffs_0_2_2_1, 2, 0, 2
+0, ntt, coeffs_0_2_2_0, coeffs_0_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 3, 0, 2
+0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_0_2_2_0, coeffs_0_2_2_1, 4, 0, 2
+0, ntt, coeffs_0_2_2_0, coeffs_0_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 5, 0, 2
+0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_0_2_2_0, coeffs_0_2_2_1, 6, 0, 2
+0, ntt, coeffs_0_2_2_0, coeffs_0_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 7, 0, 2
+0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_0_2_2_0, coeffs_0_2_2_1, 8, 0, 2
+0, ntt, coeffs_0_2_2_0, coeffs_0_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 9, 0, 2
+0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_0_2_2_0, coeffs_0_2_2_1, 10, 0, 2
+0, ntt, coeffs_0_2_2_0, coeffs_0_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 11, 0, 2
+0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_0_2_2_0, coeffs_0_2_2_1, 12, 0, 2
+0, ntt, coeffs_0_2_2_0, coeffs_0_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 13, 0, 2
 0, muli, coeffs_2_0_0, ct_2_1_0, R2_0, 0
 0, muli, coeffs_2_0_1, ct_2_1_1, R2_0, 0
 0, muli, coeffs_2_1_0, ct_2_1_0, R2_1, 1
 0, muli, coeffs_2_1_1, ct_2_1_1, R2_1, 1
 0, muli, coeffs_2_2_0, ct_2_1_0, R2_2, 2
 0, muli, coeffs_2_2_1, ct_2_1_1, R2_2, 2
-0, mul, coeffs_b_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
-0, mul, coeffs_b_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
-0, mul, coeffs_b_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
-0, mul, coeffs_b_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, 0, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, 0, 0, 1
-0, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 1, 0, 0
-0, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 1, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, 2, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, 2, 0, 1
-0, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 3, 0, 0
-0, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 3, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, 4, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, 4, 0, 1
-0, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 5, 0, 0
-0, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 5, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, 6, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, 6, 0, 1
-0, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 7, 0, 0
-0, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 7, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, 8, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, 8, 0, 1
-0, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 9, 0, 0
-0, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 9, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, 10, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, 10, 0, 1
-0, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 11, 0, 0
-0, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 11, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, 12, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, 12, 0, 1
-0, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 13, 0, 0
-0, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 13, 0, 1
-0, mul, coeffs_b_2_2_0, coeffs_2_2_0, psi_0_2_0, 2
-0, mul, coeffs_b_2_2_1, coeffs_2_2_1, psi_0_2_1, 2
-0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_b_2_2_0, coeffs_b_2_2_1, 0, 0, 2
-0, ntt, coeffs_b_2_2_0, coeffs_b_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 1, 0, 2
-0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_b_2_2_0, coeffs_b_2_2_1, 2, 0, 2
-0, ntt, coeffs_b_2_2_0, coeffs_b_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 3, 0, 2
-0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_b_2_2_0, coeffs_b_2_2_1, 4, 0, 2
-0, ntt, coeffs_b_2_2_0, coeffs_b_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 5, 0, 2
-0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_b_2_2_0, coeffs_b_2_2_1, 6, 0, 2
-0, ntt, coeffs_b_2_2_0, coeffs_b_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 7, 0, 2
-0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_b_2_2_0, coeffs_b_2_2_1, 8, 0, 2
-0, ntt, coeffs_b_2_2_0, coeffs_b_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 9, 0, 2
-0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_b_2_2_0, coeffs_b_2_2_1, 10, 0, 2
-0, ntt, coeffs_b_2_2_0, coeffs_b_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 11, 0, 2
-0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_b_2_2_0, coeffs_b_2_2_1, 12, 0, 2
-0, ntt, coeffs_b_2_2_0, coeffs_b_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 13, 0, 2
-0, mul, c2_rlk_0_0_0, coeffs_a_2_0_0, rlk_0_0_0_0, 0
-0, mul, c2_rlk_0_0_1, coeffs_a_2_0_1, rlk_0_0_0_1, 0
-0, mul, c2_rlk_0_1_0, coeffs_a_2_1_0, rlk_0_0_1_0, 1
-0, mul, c2_rlk_0_1_1, coeffs_a_2_1_1, rlk_0_0_1_1, 1
-0, mul, c2_rlk_1_0_0, coeffs_a_2_0_0, rlk_1_0_0_0, 0
-0, mul, c2_rlk_1_0_1, coeffs_a_2_0_1, rlk_1_0_0_1, 0
-0, mul, c2_rlk_1_1_0, coeffs_a_2_1_0, rlk_1_0_1_0, 1
-0, mul, c2_rlk_1_1_1, coeffs_a_2_1_1, rlk_1_0_1_1, 1
-0, mul, c2_rlk_0_2_0, coeffs_a_2_2_0, rlk_0_0_2_0, 2
-0, mul, c2_rlk_0_2_1, coeffs_a_2_2_1, rlk_0_0_2_1, 2
-0, mul, c2_rlk_1_2_0, coeffs_a_2_2_0, rlk_1_0_2_0, 2
-0, mul, c2_rlk_1_2_1, coeffs_a_2_2_1, rlk_1_0_2_1, 2
-0, mac, c2_rlk_0_0_0, coeffs_b_2_0_0, rlk_0_1_0_0, 0
-0, mac, c2_rlk_0_0_1, coeffs_b_2_0_1, rlk_0_1_0_1, 0
-0, mac, c2_rlk_0_1_0, coeffs_b_2_1_0, rlk_0_1_1_0, 1
-0, mac, c2_rlk_0_1_1, coeffs_b_2_1_1, rlk_0_1_1_1, 1
-0, mac, c2_rlk_1_0_0, coeffs_b_2_0_0, rlk_1_1_0_0, 0
-0, mac, c2_rlk_1_0_1, coeffs_b_2_0_1, rlk_1_1_0_1, 0
-0, mac, c2_rlk_1_1_0, coeffs_b_2_1_0, rlk_1_1_1_0, 1
-0, mac, c2_rlk_1_1_1, coeffs_b_2_1_1, rlk_1_1_1_1, 1
-0, mac, c2_rlk_0_2_0, coeffs_b_2_2_0, rlk_0_1_2_0, 2
-0, mac, c2_rlk_0_2_1, coeffs_b_2_2_1, rlk_0_1_2_1, 2
-0, mac, c2_rlk_1_2_0, coeffs_b_2_2_0, rlk_1_1_2_0, 2
-0, mac, c2_rlk_1_2_1, coeffs_b_2_2_1, rlk_1_1_2_1, 2
+0, mul, coeffs_1_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
+0, mul, coeffs_1_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
+0, mul, coeffs_1_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
+0, mul, coeffs_1_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, 0, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, 0, 0, 1
+0, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 1, 0, 0
+0, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 1, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, 2, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, 2, 0, 1
+0, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 3, 0, 0
+0, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 3, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, 4, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, 4, 0, 1
+0, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 5, 0, 0
+0, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 5, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, 6, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, 6, 0, 1
+0, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 7, 0, 0
+0, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 7, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, 8, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, 8, 0, 1
+0, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 9, 0, 0
+0, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 9, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, 10, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, 10, 0, 1
+0, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 11, 0, 0
+0, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 11, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, 12, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, 12, 0, 1
+0, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 13, 0, 0
+0, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 13, 0, 1
+0, mul, coeffs_1_2_2_0, coeffs_2_2_0, psi_0_2_0, 2
+0, mul, coeffs_1_2_2_1, coeffs_2_2_1, psi_0_2_1, 2
+0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_1_2_2_0, coeffs_1_2_2_1, 0, 0, 2
+0, ntt, coeffs_1_2_2_0, coeffs_1_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 1, 0, 2
+0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_1_2_2_0, coeffs_1_2_2_1, 2, 0, 2
+0, ntt, coeffs_1_2_2_0, coeffs_1_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 3, 0, 2
+0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_1_2_2_0, coeffs_1_2_2_1, 4, 0, 2
+0, ntt, coeffs_1_2_2_0, coeffs_1_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 5, 0, 2
+0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_1_2_2_0, coeffs_1_2_2_1, 6, 0, 2
+0, ntt, coeffs_1_2_2_0, coeffs_1_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 7, 0, 2
+0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_1_2_2_0, coeffs_1_2_2_1, 8, 0, 2
+0, ntt, coeffs_1_2_2_0, coeffs_1_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 9, 0, 2
+0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_1_2_2_0, coeffs_1_2_2_1, 10, 0, 2
+0, ntt, coeffs_1_2_2_0, coeffs_1_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 11, 0, 2
+0, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_1_2_2_0, coeffs_1_2_2_1, 12, 0, 2
+0, ntt, coeffs_1_2_2_0, coeffs_1_2_2_1, outtmp_2_2_0, outtmp_2_2_1, 13, 0, 2
+0, mul, c2_rlk_0_0_0, coeffs_0_2_0_0, rlk_0_0_0_0, 0
+0, mul, c2_rlk_0_0_1, coeffs_0_2_0_1, rlk_0_0_0_1, 0
+0, mul, c2_rlk_0_1_0, coeffs_0_2_1_0, rlk_0_0_1_0, 1
+0, mul, c2_rlk_0_1_1, coeffs_0_2_1_1, rlk_0_0_1_1, 1
+0, mul, c2_rlk_1_0_0, coeffs_0_2_0_0, rlk_1_0_0_0, 0
+0, mul, c2_rlk_1_0_1, coeffs_0_2_0_1, rlk_1_0_0_1, 0
+0, mul, c2_rlk_1_1_0, coeffs_0_2_1_0, rlk_1_0_1_0, 1
+0, mul, c2_rlk_1_1_1, coeffs_0_2_1_1, rlk_1_0_1_1, 1
+0, mul, c2_rlk_0_2_0, coeffs_0_2_2_0, rlk_0_0_2_0, 2
+0, mul, c2_rlk_0_2_1, coeffs_0_2_2_1, rlk_0_0_2_1, 2
+0, mul, c2_rlk_1_2_0, coeffs_0_2_2_0, rlk_1_0_2_0, 2
+0, mul, c2_rlk_1_2_1, coeffs_0_2_2_1, rlk_1_0_2_1, 2
+0, mac, c2_rlk_0_0_0, coeffs_1_2_0_0, rlk_0_1_0_0, 0
+0, mac, c2_rlk_0_0_1, coeffs_1_2_0_1, rlk_0_1_0_1, 0
+0, mac, c2_rlk_0_1_0, coeffs_1_2_1_0, rlk_0_1_1_0, 1
+0, mac, c2_rlk_0_1_1, coeffs_1_2_1_1, rlk_0_1_1_1, 1
+0, mac, c2_rlk_1_0_0, coeffs_1_2_0_0, rlk_1_1_0_0, 0
+0, mac, c2_rlk_1_0_1, coeffs_1_2_0_1, rlk_1_1_0_1, 0
+0, mac, c2_rlk_1_1_0, coeffs_1_2_1_0, rlk_1_1_1_0, 1
+0, mac, c2_rlk_1_1_1, coeffs_1_2_1_1, rlk_1_1_1_1, 1
+0, mac, c2_rlk_0_2_0, coeffs_1_2_2_0, rlk_0_1_2_0, 2
+0, mac, c2_rlk_0_2_1, coeffs_1_2_2_1, rlk_0_1_2_1, 2
+0, mac, c2_rlk_1_2_0, coeffs_1_2_2_0, rlk_1_1_2_0, 2
+0, mac, c2_rlk_1_2_1, coeffs_1_2_2_1, rlk_1_1_2_1, 2
 0, intt, outtmp_0_2_0, outtmp_0_2_1, c2_rlk_0_2_0, c2_rlk_0_2_1, 0, 0, 2
 0, intt, y_0_2_0, y_0_2_1, outtmp_0_2_0, outtmp_0_2_1, 1, 0, 2
 0, intt, outtmp_0_2_0, outtmp_0_2_1, y_0_2_0, y_0_2_1, 2, 0, 2

--- a/p-isa_tools/kerngen/tests/kernel_examples/relin_kernel/output.bgv.16k_l2_m3_p-rns_s-part.relin
+++ b/p-isa_tools/kerngen/tests/kernel_examples/relin_kernel/output.bgv.16k_l2_m3_p-rns_s-part.relin
@@ -44,132 +44,132 @@
 14, muli, coeffs_2_1_1, ct_2_0_1, R2_1, 1
 14, muli, coeffs_2_2_0, ct_2_0_0, R2_2, 2
 14, muli, coeffs_2_2_1, ct_2_0_1, R2_2, 2
-14, mul, coeffs_a_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
-14, mul, coeffs_a_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
-14, mul, coeffs_a_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
-14, mul, coeffs_a_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, w_0_0_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, w_1_0_0, 1
-14, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_1_0, 0
-14, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_1_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, w_0_2_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, w_1_2_0, 1
-14, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_3_0, 0
-14, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_3_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, w_0_4_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, w_1_4_0, 1
-14, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_5_0, 0
-14, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_5_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, w_0_6_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, w_1_6_0, 1
-14, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_7_0, 0
-14, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_7_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, w_0_8_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, w_1_8_0, 1
-14, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_9_0, 0
-14, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_9_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, w_0_10_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, w_1_10_0, 1
-14, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_11_0, 0
-14, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_11_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, w_0_12_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, w_1_12_0, 1
-14, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_13_0, 0
-14, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_13_0, 1
-14, mul, coeffs_a_2_2_0, coeffs_2_2_0, psi_0_2_0, 2
-14, mul, coeffs_a_2_2_1, coeffs_2_2_1, psi_0_2_1, 2
-14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_a_2_2_0, coeffs_a_2_2_1, w_2_0_0, 2
-14, ntt, coeffs_a_2_2_0, coeffs_a_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_1_0, 2
-14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_a_2_2_0, coeffs_a_2_2_1, w_2_2_0, 2
-14, ntt, coeffs_a_2_2_0, coeffs_a_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_3_0, 2
-14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_a_2_2_0, coeffs_a_2_2_1, w_2_4_0, 2
-14, ntt, coeffs_a_2_2_0, coeffs_a_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_5_0, 2
-14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_a_2_2_0, coeffs_a_2_2_1, w_2_6_0, 2
-14, ntt, coeffs_a_2_2_0, coeffs_a_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_7_0, 2
-14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_a_2_2_0, coeffs_a_2_2_1, w_2_8_0, 2
-14, ntt, coeffs_a_2_2_0, coeffs_a_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_9_0, 2
-14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_a_2_2_0, coeffs_a_2_2_1, w_2_10_0, 2
-14, ntt, coeffs_a_2_2_0, coeffs_a_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_11_0, 2
-14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_a_2_2_0, coeffs_a_2_2_1, w_2_12_0, 2
-14, ntt, coeffs_a_2_2_0, coeffs_a_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_13_0, 2
+14, mul, coeffs_0_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
+14, mul, coeffs_0_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
+14, mul, coeffs_0_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
+14, mul, coeffs_0_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, w_0_0_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, w_1_0_0, 1
+14, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_1_0, 0
+14, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_1_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, w_0_2_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, w_1_2_0, 1
+14, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_3_0, 0
+14, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_3_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, w_0_4_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, w_1_4_0, 1
+14, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_5_0, 0
+14, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_5_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, w_0_6_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, w_1_6_0, 1
+14, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_7_0, 0
+14, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_7_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, w_0_8_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, w_1_8_0, 1
+14, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_9_0, 0
+14, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_9_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, w_0_10_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, w_1_10_0, 1
+14, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_11_0, 0
+14, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_11_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, w_0_12_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, w_1_12_0, 1
+14, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_13_0, 0
+14, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_13_0, 1
+14, mul, coeffs_0_2_2_0, coeffs_2_2_0, psi_0_2_0, 2
+14, mul, coeffs_0_2_2_1, coeffs_2_2_1, psi_0_2_1, 2
+14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_0_2_2_0, coeffs_0_2_2_1, w_2_0_0, 2
+14, ntt, coeffs_0_2_2_0, coeffs_0_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_1_0, 2
+14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_0_2_2_0, coeffs_0_2_2_1, w_2_2_0, 2
+14, ntt, coeffs_0_2_2_0, coeffs_0_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_3_0, 2
+14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_0_2_2_0, coeffs_0_2_2_1, w_2_4_0, 2
+14, ntt, coeffs_0_2_2_0, coeffs_0_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_5_0, 2
+14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_0_2_2_0, coeffs_0_2_2_1, w_2_6_0, 2
+14, ntt, coeffs_0_2_2_0, coeffs_0_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_7_0, 2
+14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_0_2_2_0, coeffs_0_2_2_1, w_2_8_0, 2
+14, ntt, coeffs_0_2_2_0, coeffs_0_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_9_0, 2
+14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_0_2_2_0, coeffs_0_2_2_1, w_2_10_0, 2
+14, ntt, coeffs_0_2_2_0, coeffs_0_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_11_0, 2
+14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_0_2_2_0, coeffs_0_2_2_1, w_2_12_0, 2
+14, ntt, coeffs_0_2_2_0, coeffs_0_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_13_0, 2
 14, muli, coeffs_2_0_0, ct_2_1_0, R2_0, 0
 14, muli, coeffs_2_0_1, ct_2_1_1, R2_0, 0
 14, muli, coeffs_2_1_0, ct_2_1_0, R2_1, 1
 14, muli, coeffs_2_1_1, ct_2_1_1, R2_1, 1
 14, muli, coeffs_2_2_0, ct_2_1_0, R2_2, 2
 14, muli, coeffs_2_2_1, ct_2_1_1, R2_2, 2
-14, mul, coeffs_b_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
-14, mul, coeffs_b_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
-14, mul, coeffs_b_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
-14, mul, coeffs_b_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, w_0_0_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, w_1_0_0, 1
-14, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_1_0, 0
-14, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_1_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, w_0_2_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, w_1_2_0, 1
-14, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_3_0, 0
-14, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_3_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, w_0_4_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, w_1_4_0, 1
-14, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_5_0, 0
-14, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_5_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, w_0_6_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, w_1_6_0, 1
-14, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_7_0, 0
-14, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_7_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, w_0_8_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, w_1_8_0, 1
-14, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_9_0, 0
-14, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_9_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, w_0_10_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, w_1_10_0, 1
-14, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_11_0, 0
-14, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_11_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, w_0_12_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, w_1_12_0, 1
-14, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_13_0, 0
-14, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_13_0, 1
-14, mul, coeffs_b_2_2_0, coeffs_2_2_0, psi_0_2_0, 2
-14, mul, coeffs_b_2_2_1, coeffs_2_2_1, psi_0_2_1, 2
-14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_b_2_2_0, coeffs_b_2_2_1, w_2_0_0, 2
-14, ntt, coeffs_b_2_2_0, coeffs_b_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_1_0, 2
-14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_b_2_2_0, coeffs_b_2_2_1, w_2_2_0, 2
-14, ntt, coeffs_b_2_2_0, coeffs_b_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_3_0, 2
-14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_b_2_2_0, coeffs_b_2_2_1, w_2_4_0, 2
-14, ntt, coeffs_b_2_2_0, coeffs_b_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_5_0, 2
-14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_b_2_2_0, coeffs_b_2_2_1, w_2_6_0, 2
-14, ntt, coeffs_b_2_2_0, coeffs_b_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_7_0, 2
-14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_b_2_2_0, coeffs_b_2_2_1, w_2_8_0, 2
-14, ntt, coeffs_b_2_2_0, coeffs_b_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_9_0, 2
-14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_b_2_2_0, coeffs_b_2_2_1, w_2_10_0, 2
-14, ntt, coeffs_b_2_2_0, coeffs_b_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_11_0, 2
-14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_b_2_2_0, coeffs_b_2_2_1, w_2_12_0, 2
-14, ntt, coeffs_b_2_2_0, coeffs_b_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_13_0, 2
-14, mul, c2_rlk_0_0_0, coeffs_a_2_0_0, rlk_0_0_0_0, 0
-14, mul, c2_rlk_0_0_1, coeffs_a_2_0_1, rlk_0_0_0_1, 0
-14, mul, c2_rlk_0_1_0, coeffs_a_2_1_0, rlk_0_0_1_0, 1
-14, mul, c2_rlk_0_1_1, coeffs_a_2_1_1, rlk_0_0_1_1, 1
-14, mul, c2_rlk_1_0_0, coeffs_a_2_0_0, rlk_1_0_0_0, 0
-14, mul, c2_rlk_1_0_1, coeffs_a_2_0_1, rlk_1_0_0_1, 0
-14, mul, c2_rlk_1_1_0, coeffs_a_2_1_0, rlk_1_0_1_0, 1
-14, mul, c2_rlk_1_1_1, coeffs_a_2_1_1, rlk_1_0_1_1, 1
-14, mul, c2_rlk_0_2_0, coeffs_a_2_2_0, rlk_0_0_2_0, 2
-14, mul, c2_rlk_0_2_1, coeffs_a_2_2_1, rlk_0_0_2_1, 2
-14, mul, c2_rlk_1_2_0, coeffs_a_2_2_0, rlk_1_0_2_0, 2
-14, mul, c2_rlk_1_2_1, coeffs_a_2_2_1, rlk_1_0_2_1, 2
-14, mac, c2_rlk_0_0_0, coeffs_b_2_0_0, rlk_0_1_0_0, 0
-14, mac, c2_rlk_0_0_1, coeffs_b_2_0_1, rlk_0_1_0_1, 0
-14, mac, c2_rlk_0_1_0, coeffs_b_2_1_0, rlk_0_1_1_0, 1
-14, mac, c2_rlk_0_1_1, coeffs_b_2_1_1, rlk_0_1_1_1, 1
-14, mac, c2_rlk_1_0_0, coeffs_b_2_0_0, rlk_1_1_0_0, 0
-14, mac, c2_rlk_1_0_1, coeffs_b_2_0_1, rlk_1_1_0_1, 0
-14, mac, c2_rlk_1_1_0, coeffs_b_2_1_0, rlk_1_1_1_0, 1
-14, mac, c2_rlk_1_1_1, coeffs_b_2_1_1, rlk_1_1_1_1, 1
-14, mac, c2_rlk_0_2_0, coeffs_b_2_2_0, rlk_0_1_2_0, 2
-14, mac, c2_rlk_0_2_1, coeffs_b_2_2_1, rlk_0_1_2_1, 2
-14, mac, c2_rlk_1_2_0, coeffs_b_2_2_0, rlk_1_1_2_0, 2
-14, mac, c2_rlk_1_2_1, coeffs_b_2_2_1, rlk_1_1_2_1, 2
+14, mul, coeffs_1_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
+14, mul, coeffs_1_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
+14, mul, coeffs_1_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
+14, mul, coeffs_1_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, w_0_0_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, w_1_0_0, 1
+14, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_1_0, 0
+14, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_1_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, w_0_2_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, w_1_2_0, 1
+14, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_3_0, 0
+14, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_3_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, w_0_4_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, w_1_4_0, 1
+14, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_5_0, 0
+14, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_5_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, w_0_6_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, w_1_6_0, 1
+14, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_7_0, 0
+14, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_7_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, w_0_8_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, w_1_8_0, 1
+14, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_9_0, 0
+14, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_9_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, w_0_10_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, w_1_10_0, 1
+14, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_11_0, 0
+14, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_11_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, w_0_12_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, w_1_12_0, 1
+14, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_13_0, 0
+14, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_13_0, 1
+14, mul, coeffs_1_2_2_0, coeffs_2_2_0, psi_0_2_0, 2
+14, mul, coeffs_1_2_2_1, coeffs_2_2_1, psi_0_2_1, 2
+14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_1_2_2_0, coeffs_1_2_2_1, w_2_0_0, 2
+14, ntt, coeffs_1_2_2_0, coeffs_1_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_1_0, 2
+14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_1_2_2_0, coeffs_1_2_2_1, w_2_2_0, 2
+14, ntt, coeffs_1_2_2_0, coeffs_1_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_3_0, 2
+14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_1_2_2_0, coeffs_1_2_2_1, w_2_4_0, 2
+14, ntt, coeffs_1_2_2_0, coeffs_1_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_5_0, 2
+14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_1_2_2_0, coeffs_1_2_2_1, w_2_6_0, 2
+14, ntt, coeffs_1_2_2_0, coeffs_1_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_7_0, 2
+14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_1_2_2_0, coeffs_1_2_2_1, w_2_8_0, 2
+14, ntt, coeffs_1_2_2_0, coeffs_1_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_9_0, 2
+14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_1_2_2_0, coeffs_1_2_2_1, w_2_10_0, 2
+14, ntt, coeffs_1_2_2_0, coeffs_1_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_11_0, 2
+14, ntt, outtmp_2_2_0, outtmp_2_2_1, coeffs_1_2_2_0, coeffs_1_2_2_1, w_2_12_0, 2
+14, ntt, coeffs_1_2_2_0, coeffs_1_2_2_1, outtmp_2_2_0, outtmp_2_2_1, w_2_13_0, 2
+14, mul, c2_rlk_0_0_0, coeffs_0_2_0_0, rlk_0_0_0_0, 0
+14, mul, c2_rlk_0_0_1, coeffs_0_2_0_1, rlk_0_0_0_1, 0
+14, mul, c2_rlk_0_1_0, coeffs_0_2_1_0, rlk_0_0_1_0, 1
+14, mul, c2_rlk_0_1_1, coeffs_0_2_1_1, rlk_0_0_1_1, 1
+14, mul, c2_rlk_1_0_0, coeffs_0_2_0_0, rlk_1_0_0_0, 0
+14, mul, c2_rlk_1_0_1, coeffs_0_2_0_1, rlk_1_0_0_1, 0
+14, mul, c2_rlk_1_1_0, coeffs_0_2_1_0, rlk_1_0_1_0, 1
+14, mul, c2_rlk_1_1_1, coeffs_0_2_1_1, rlk_1_0_1_1, 1
+14, mul, c2_rlk_0_2_0, coeffs_0_2_2_0, rlk_0_0_2_0, 2
+14, mul, c2_rlk_0_2_1, coeffs_0_2_2_1, rlk_0_0_2_1, 2
+14, mul, c2_rlk_1_2_0, coeffs_0_2_2_0, rlk_1_0_2_0, 2
+14, mul, c2_rlk_1_2_1, coeffs_0_2_2_1, rlk_1_0_2_1, 2
+14, mac, c2_rlk_0_0_0, coeffs_1_2_0_0, rlk_0_1_0_0, 0
+14, mac, c2_rlk_0_0_1, coeffs_1_2_0_1, rlk_0_1_0_1, 0
+14, mac, c2_rlk_0_1_0, coeffs_1_2_1_0, rlk_0_1_1_0, 1
+14, mac, c2_rlk_0_1_1, coeffs_1_2_1_1, rlk_0_1_1_1, 1
+14, mac, c2_rlk_1_0_0, coeffs_1_2_0_0, rlk_1_1_0_0, 0
+14, mac, c2_rlk_1_0_1, coeffs_1_2_0_1, rlk_1_1_0_1, 0
+14, mac, c2_rlk_1_1_0, coeffs_1_2_1_0, rlk_1_1_1_0, 1
+14, mac, c2_rlk_1_1_1, coeffs_1_2_1_1, rlk_1_1_1_1, 1
+14, mac, c2_rlk_0_2_0, coeffs_1_2_2_0, rlk_0_1_2_0, 2
+14, mac, c2_rlk_0_2_1, coeffs_1_2_2_1, rlk_0_1_2_1, 2
+14, mac, c2_rlk_1_2_0, coeffs_1_2_2_0, rlk_1_1_2_0, 2
+14, mac, c2_rlk_1_2_1, coeffs_1_2_2_1, rlk_1_1_2_1, 2
 14, intt, outtmp_0_2_0, outtmp_0_2_1, c2_rlk_0_2_0, c2_rlk_0_2_1, w_2_0_0, 2
 14, intt, y_0_2_0, y_0_2_1, outtmp_0_2_0, outtmp_0_2_1, w_2_1_0, 2
 14, intt, outtmp_0_2_0, outtmp_0_2_1, y_0_2_0, y_0_2_1, w_2_2_0, 2

--- a/p-isa_tools/kerngen/tests/kernel_examples/relin_kernel/output.bgv.16k_l2_m4.relin
+++ b/p-isa_tools/kerngen/tests/kernel_examples/relin_kernel/output.bgv.16k_l2_m4.relin
@@ -44,132 +44,132 @@
 0, muli, coeffs_2_1_1, ct_2_0_1, R2_1, 1
 0, muli, coeffs_2_3_0, ct_2_0_0, R2_3, 3
 0, muli, coeffs_2_3_1, ct_2_0_1, R2_3, 3
-0, mul, coeffs_a_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
-0, mul, coeffs_a_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
-0, mul, coeffs_a_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
-0, mul, coeffs_a_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, 0, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, 0, 0, 1
-0, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 1, 0, 0
-0, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 1, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, 2, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, 2, 0, 1
-0, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 3, 0, 0
-0, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 3, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, 4, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, 4, 0, 1
-0, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 5, 0, 0
-0, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 5, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, 6, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, 6, 0, 1
-0, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 7, 0, 0
-0, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 7, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, 8, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, 8, 0, 1
-0, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 9, 0, 0
-0, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 9, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, 10, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, 10, 0, 1
-0, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 11, 0, 0
-0, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 11, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, 12, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, 12, 0, 1
-0, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 13, 0, 0
-0, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 13, 0, 1
-0, mul, coeffs_a_2_3_0, coeffs_2_3_0, psi_0_3_0, 3
-0, mul, coeffs_a_2_3_1, coeffs_2_3_1, psi_0_3_1, 3
-0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_a_2_3_0, coeffs_a_2_3_1, 0, 0, 3
-0, ntt, coeffs_a_2_3_0, coeffs_a_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 1, 0, 3
-0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_a_2_3_0, coeffs_a_2_3_1, 2, 0, 3
-0, ntt, coeffs_a_2_3_0, coeffs_a_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 3, 0, 3
-0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_a_2_3_0, coeffs_a_2_3_1, 4, 0, 3
-0, ntt, coeffs_a_2_3_0, coeffs_a_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 5, 0, 3
-0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_a_2_3_0, coeffs_a_2_3_1, 6, 0, 3
-0, ntt, coeffs_a_2_3_0, coeffs_a_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 7, 0, 3
-0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_a_2_3_0, coeffs_a_2_3_1, 8, 0, 3
-0, ntt, coeffs_a_2_3_0, coeffs_a_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 9, 0, 3
-0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_a_2_3_0, coeffs_a_2_3_1, 10, 0, 3
-0, ntt, coeffs_a_2_3_0, coeffs_a_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 11, 0, 3
-0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_a_2_3_0, coeffs_a_2_3_1, 12, 0, 3
-0, ntt, coeffs_a_2_3_0, coeffs_a_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 13, 0, 3
+0, mul, coeffs_0_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
+0, mul, coeffs_0_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
+0, mul, coeffs_0_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
+0, mul, coeffs_0_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, 0, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, 0, 0, 1
+0, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 1, 0, 0
+0, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 1, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, 2, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, 2, 0, 1
+0, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 3, 0, 0
+0, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 3, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, 4, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, 4, 0, 1
+0, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 5, 0, 0
+0, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 5, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, 6, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, 6, 0, 1
+0, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 7, 0, 0
+0, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 7, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, 8, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, 8, 0, 1
+0, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 9, 0, 0
+0, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 9, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, 10, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, 10, 0, 1
+0, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 11, 0, 0
+0, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 11, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, 12, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, 12, 0, 1
+0, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 13, 0, 0
+0, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 13, 0, 1
+0, mul, coeffs_0_2_3_0, coeffs_2_3_0, psi_0_3_0, 3
+0, mul, coeffs_0_2_3_1, coeffs_2_3_1, psi_0_3_1, 3
+0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_0_2_3_0, coeffs_0_2_3_1, 0, 0, 3
+0, ntt, coeffs_0_2_3_0, coeffs_0_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 1, 0, 3
+0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_0_2_3_0, coeffs_0_2_3_1, 2, 0, 3
+0, ntt, coeffs_0_2_3_0, coeffs_0_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 3, 0, 3
+0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_0_2_3_0, coeffs_0_2_3_1, 4, 0, 3
+0, ntt, coeffs_0_2_3_0, coeffs_0_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 5, 0, 3
+0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_0_2_3_0, coeffs_0_2_3_1, 6, 0, 3
+0, ntt, coeffs_0_2_3_0, coeffs_0_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 7, 0, 3
+0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_0_2_3_0, coeffs_0_2_3_1, 8, 0, 3
+0, ntt, coeffs_0_2_3_0, coeffs_0_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 9, 0, 3
+0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_0_2_3_0, coeffs_0_2_3_1, 10, 0, 3
+0, ntt, coeffs_0_2_3_0, coeffs_0_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 11, 0, 3
+0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_0_2_3_0, coeffs_0_2_3_1, 12, 0, 3
+0, ntt, coeffs_0_2_3_0, coeffs_0_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 13, 0, 3
 0, muli, coeffs_2_0_0, ct_2_1_0, R2_0, 0
 0, muli, coeffs_2_0_1, ct_2_1_1, R2_0, 0
 0, muli, coeffs_2_1_0, ct_2_1_0, R2_1, 1
 0, muli, coeffs_2_1_1, ct_2_1_1, R2_1, 1
 0, muli, coeffs_2_3_0, ct_2_1_0, R2_3, 3
 0, muli, coeffs_2_3_1, ct_2_1_1, R2_3, 3
-0, mul, coeffs_b_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
-0, mul, coeffs_b_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
-0, mul, coeffs_b_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
-0, mul, coeffs_b_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, 0, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, 0, 0, 1
-0, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 1, 0, 0
-0, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 1, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, 2, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, 2, 0, 1
-0, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 3, 0, 0
-0, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 3, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, 4, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, 4, 0, 1
-0, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 5, 0, 0
-0, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 5, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, 6, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, 6, 0, 1
-0, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 7, 0, 0
-0, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 7, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, 8, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, 8, 0, 1
-0, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 9, 0, 0
-0, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 9, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, 10, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, 10, 0, 1
-0, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 11, 0, 0
-0, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 11, 0, 1
-0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, 12, 0, 0
-0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, 12, 0, 1
-0, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 13, 0, 0
-0, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 13, 0, 1
-0, mul, coeffs_b_2_3_0, coeffs_2_3_0, psi_0_3_0, 3
-0, mul, coeffs_b_2_3_1, coeffs_2_3_1, psi_0_3_1, 3
-0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_b_2_3_0, coeffs_b_2_3_1, 0, 0, 3
-0, ntt, coeffs_b_2_3_0, coeffs_b_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 1, 0, 3
-0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_b_2_3_0, coeffs_b_2_3_1, 2, 0, 3
-0, ntt, coeffs_b_2_3_0, coeffs_b_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 3, 0, 3
-0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_b_2_3_0, coeffs_b_2_3_1, 4, 0, 3
-0, ntt, coeffs_b_2_3_0, coeffs_b_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 5, 0, 3
-0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_b_2_3_0, coeffs_b_2_3_1, 6, 0, 3
-0, ntt, coeffs_b_2_3_0, coeffs_b_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 7, 0, 3
-0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_b_2_3_0, coeffs_b_2_3_1, 8, 0, 3
-0, ntt, coeffs_b_2_3_0, coeffs_b_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 9, 0, 3
-0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_b_2_3_0, coeffs_b_2_3_1, 10, 0, 3
-0, ntt, coeffs_b_2_3_0, coeffs_b_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 11, 0, 3
-0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_b_2_3_0, coeffs_b_2_3_1, 12, 0, 3
-0, ntt, coeffs_b_2_3_0, coeffs_b_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 13, 0, 3
-0, mul, c2_rlk_0_0_0, coeffs_a_2_0_0, rlk_0_0_0_0, 0
-0, mul, c2_rlk_0_0_1, coeffs_a_2_0_1, rlk_0_0_0_1, 0
-0, mul, c2_rlk_0_1_0, coeffs_a_2_1_0, rlk_0_0_1_0, 1
-0, mul, c2_rlk_0_1_1, coeffs_a_2_1_1, rlk_0_0_1_1, 1
-0, mul, c2_rlk_1_0_0, coeffs_a_2_0_0, rlk_1_0_0_0, 0
-0, mul, c2_rlk_1_0_1, coeffs_a_2_0_1, rlk_1_0_0_1, 0
-0, mul, c2_rlk_1_1_0, coeffs_a_2_1_0, rlk_1_0_1_0, 1
-0, mul, c2_rlk_1_1_1, coeffs_a_2_1_1, rlk_1_0_1_1, 1
-0, mul, c2_rlk_0_3_0, coeffs_a_2_3_0, rlk_0_0_3_0, 3
-0, mul, c2_rlk_0_3_1, coeffs_a_2_3_1, rlk_0_0_3_1, 3
-0, mul, c2_rlk_1_3_0, coeffs_a_2_3_0, rlk_1_0_3_0, 3
-0, mul, c2_rlk_1_3_1, coeffs_a_2_3_1, rlk_1_0_3_1, 3
-0, mac, c2_rlk_0_0_0, coeffs_b_2_0_0, rlk_0_1_0_0, 0
-0, mac, c2_rlk_0_0_1, coeffs_b_2_0_1, rlk_0_1_0_1, 0
-0, mac, c2_rlk_0_1_0, coeffs_b_2_1_0, rlk_0_1_1_0, 1
-0, mac, c2_rlk_0_1_1, coeffs_b_2_1_1, rlk_0_1_1_1, 1
-0, mac, c2_rlk_1_0_0, coeffs_b_2_0_0, rlk_1_1_0_0, 0
-0, mac, c2_rlk_1_0_1, coeffs_b_2_0_1, rlk_1_1_0_1, 0
-0, mac, c2_rlk_1_1_0, coeffs_b_2_1_0, rlk_1_1_1_0, 1
-0, mac, c2_rlk_1_1_1, coeffs_b_2_1_1, rlk_1_1_1_1, 1
-0, mac, c2_rlk_0_3_0, coeffs_b_2_3_0, rlk_0_1_3_0, 3
-0, mac, c2_rlk_0_3_1, coeffs_b_2_3_1, rlk_0_1_3_1, 3
-0, mac, c2_rlk_1_3_0, coeffs_b_2_3_0, rlk_1_1_3_0, 3
-0, mac, c2_rlk_1_3_1, coeffs_b_2_3_1, rlk_1_1_3_1, 3
+0, mul, coeffs_1_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
+0, mul, coeffs_1_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
+0, mul, coeffs_1_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
+0, mul, coeffs_1_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, 0, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, 0, 0, 1
+0, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 1, 0, 0
+0, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 1, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, 2, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, 2, 0, 1
+0, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 3, 0, 0
+0, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 3, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, 4, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, 4, 0, 1
+0, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 5, 0, 0
+0, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 5, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, 6, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, 6, 0, 1
+0, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 7, 0, 0
+0, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 7, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, 8, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, 8, 0, 1
+0, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 9, 0, 0
+0, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 9, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, 10, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, 10, 0, 1
+0, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 11, 0, 0
+0, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 11, 0, 1
+0, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, 12, 0, 0
+0, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, 12, 0, 1
+0, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, 13, 0, 0
+0, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, 13, 0, 1
+0, mul, coeffs_1_2_3_0, coeffs_2_3_0, psi_0_3_0, 3
+0, mul, coeffs_1_2_3_1, coeffs_2_3_1, psi_0_3_1, 3
+0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_1_2_3_0, coeffs_1_2_3_1, 0, 0, 3
+0, ntt, coeffs_1_2_3_0, coeffs_1_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 1, 0, 3
+0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_1_2_3_0, coeffs_1_2_3_1, 2, 0, 3
+0, ntt, coeffs_1_2_3_0, coeffs_1_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 3, 0, 3
+0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_1_2_3_0, coeffs_1_2_3_1, 4, 0, 3
+0, ntt, coeffs_1_2_3_0, coeffs_1_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 5, 0, 3
+0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_1_2_3_0, coeffs_1_2_3_1, 6, 0, 3
+0, ntt, coeffs_1_2_3_0, coeffs_1_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 7, 0, 3
+0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_1_2_3_0, coeffs_1_2_3_1, 8, 0, 3
+0, ntt, coeffs_1_2_3_0, coeffs_1_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 9, 0, 3
+0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_1_2_3_0, coeffs_1_2_3_1, 10, 0, 3
+0, ntt, coeffs_1_2_3_0, coeffs_1_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 11, 0, 3
+0, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_1_2_3_0, coeffs_1_2_3_1, 12, 0, 3
+0, ntt, coeffs_1_2_3_0, coeffs_1_2_3_1, outtmp_2_3_0, outtmp_2_3_1, 13, 0, 3
+0, mul, c2_rlk_0_0_0, coeffs_0_2_0_0, rlk_0_0_0_0, 0
+0, mul, c2_rlk_0_0_1, coeffs_0_2_0_1, rlk_0_0_0_1, 0
+0, mul, c2_rlk_0_1_0, coeffs_0_2_1_0, rlk_0_0_1_0, 1
+0, mul, c2_rlk_0_1_1, coeffs_0_2_1_1, rlk_0_0_1_1, 1
+0, mul, c2_rlk_1_0_0, coeffs_0_2_0_0, rlk_1_0_0_0, 0
+0, mul, c2_rlk_1_0_1, coeffs_0_2_0_1, rlk_1_0_0_1, 0
+0, mul, c2_rlk_1_1_0, coeffs_0_2_1_0, rlk_1_0_1_0, 1
+0, mul, c2_rlk_1_1_1, coeffs_0_2_1_1, rlk_1_0_1_1, 1
+0, mul, c2_rlk_0_3_0, coeffs_0_2_3_0, rlk_0_0_3_0, 3
+0, mul, c2_rlk_0_3_1, coeffs_0_2_3_1, rlk_0_0_3_1, 3
+0, mul, c2_rlk_1_3_0, coeffs_0_2_3_0, rlk_1_0_3_0, 3
+0, mul, c2_rlk_1_3_1, coeffs_0_2_3_1, rlk_1_0_3_1, 3
+0, mac, c2_rlk_0_0_0, coeffs_1_2_0_0, rlk_0_1_0_0, 0
+0, mac, c2_rlk_0_0_1, coeffs_1_2_0_1, rlk_0_1_0_1, 0
+0, mac, c2_rlk_0_1_0, coeffs_1_2_1_0, rlk_0_1_1_0, 1
+0, mac, c2_rlk_0_1_1, coeffs_1_2_1_1, rlk_0_1_1_1, 1
+0, mac, c2_rlk_1_0_0, coeffs_1_2_0_0, rlk_1_1_0_0, 0
+0, mac, c2_rlk_1_0_1, coeffs_1_2_0_1, rlk_1_1_0_1, 0
+0, mac, c2_rlk_1_1_0, coeffs_1_2_1_0, rlk_1_1_1_0, 1
+0, mac, c2_rlk_1_1_1, coeffs_1_2_1_1, rlk_1_1_1_1, 1
+0, mac, c2_rlk_0_3_0, coeffs_1_2_3_0, rlk_0_1_3_0, 3
+0, mac, c2_rlk_0_3_1, coeffs_1_2_3_1, rlk_0_1_3_1, 3
+0, mac, c2_rlk_1_3_0, coeffs_1_2_3_0, rlk_1_1_3_0, 3
+0, mac, c2_rlk_1_3_1, coeffs_1_2_3_1, rlk_1_1_3_1, 3
 0, intt, outtmp_0_3_0, outtmp_0_3_1, c2_rlk_0_3_0, c2_rlk_0_3_1, 0, 0, 3
 0, intt, y_0_3_0, y_0_3_1, outtmp_0_3_0, outtmp_0_3_1, 1, 0, 3
 0, intt, outtmp_0_3_0, outtmp_0_3_1, y_0_3_0, y_0_3_1, 2, 0, 3

--- a/p-isa_tools/kerngen/tests/kernel_examples/relin_kernel/output.bgv.16k_l2_m4_p-rns_s-part.relin
+++ b/p-isa_tools/kerngen/tests/kernel_examples/relin_kernel/output.bgv.16k_l2_m4_p-rns_s-part.relin
@@ -44,132 +44,132 @@
 14, muli, coeffs_2_1_1, ct_2_0_1, R2_1, 1
 14, muli, coeffs_2_3_0, ct_2_0_0, R2_3, 3
 14, muli, coeffs_2_3_1, ct_2_0_1, R2_3, 3
-14, mul, coeffs_a_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
-14, mul, coeffs_a_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
-14, mul, coeffs_a_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
-14, mul, coeffs_a_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, w_0_0_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, w_1_0_0, 1
-14, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_1_0, 0
-14, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_1_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, w_0_2_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, w_1_2_0, 1
-14, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_3_0, 0
-14, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_3_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, w_0_4_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, w_1_4_0, 1
-14, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_5_0, 0
-14, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_5_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, w_0_6_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, w_1_6_0, 1
-14, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_7_0, 0
-14, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_7_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, w_0_8_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, w_1_8_0, 1
-14, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_9_0, 0
-14, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_9_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, w_0_10_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, w_1_10_0, 1
-14, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_11_0, 0
-14, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_11_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_a_2_0_0, coeffs_a_2_0_1, w_0_12_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_a_2_1_0, coeffs_a_2_1_1, w_1_12_0, 1
-14, ntt, coeffs_a_2_0_0, coeffs_a_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_13_0, 0
-14, ntt, coeffs_a_2_1_0, coeffs_a_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_13_0, 1
-14, mul, coeffs_a_2_3_0, coeffs_2_3_0, psi_0_3_0, 3
-14, mul, coeffs_a_2_3_1, coeffs_2_3_1, psi_0_3_1, 3
-14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_a_2_3_0, coeffs_a_2_3_1, w_3_0_0, 3
-14, ntt, coeffs_a_2_3_0, coeffs_a_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_1_0, 3
-14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_a_2_3_0, coeffs_a_2_3_1, w_3_2_0, 3
-14, ntt, coeffs_a_2_3_0, coeffs_a_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_3_0, 3
-14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_a_2_3_0, coeffs_a_2_3_1, w_3_4_0, 3
-14, ntt, coeffs_a_2_3_0, coeffs_a_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_5_0, 3
-14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_a_2_3_0, coeffs_a_2_3_1, w_3_6_0, 3
-14, ntt, coeffs_a_2_3_0, coeffs_a_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_7_0, 3
-14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_a_2_3_0, coeffs_a_2_3_1, w_3_8_0, 3
-14, ntt, coeffs_a_2_3_0, coeffs_a_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_9_0, 3
-14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_a_2_3_0, coeffs_a_2_3_1, w_3_10_0, 3
-14, ntt, coeffs_a_2_3_0, coeffs_a_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_11_0, 3
-14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_a_2_3_0, coeffs_a_2_3_1, w_3_12_0, 3
-14, ntt, coeffs_a_2_3_0, coeffs_a_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_13_0, 3
+14, mul, coeffs_0_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
+14, mul, coeffs_0_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
+14, mul, coeffs_0_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
+14, mul, coeffs_0_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, w_0_0_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, w_1_0_0, 1
+14, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_1_0, 0
+14, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_1_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, w_0_2_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, w_1_2_0, 1
+14, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_3_0, 0
+14, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_3_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, w_0_4_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, w_1_4_0, 1
+14, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_5_0, 0
+14, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_5_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, w_0_6_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, w_1_6_0, 1
+14, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_7_0, 0
+14, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_7_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, w_0_8_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, w_1_8_0, 1
+14, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_9_0, 0
+14, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_9_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, w_0_10_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, w_1_10_0, 1
+14, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_11_0, 0
+14, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_11_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_0_2_0_0, coeffs_0_2_0_1, w_0_12_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_0_2_1_0, coeffs_0_2_1_1, w_1_12_0, 1
+14, ntt, coeffs_0_2_0_0, coeffs_0_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_13_0, 0
+14, ntt, coeffs_0_2_1_0, coeffs_0_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_13_0, 1
+14, mul, coeffs_0_2_3_0, coeffs_2_3_0, psi_0_3_0, 3
+14, mul, coeffs_0_2_3_1, coeffs_2_3_1, psi_0_3_1, 3
+14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_0_2_3_0, coeffs_0_2_3_1, w_3_0_0, 3
+14, ntt, coeffs_0_2_3_0, coeffs_0_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_1_0, 3
+14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_0_2_3_0, coeffs_0_2_3_1, w_3_2_0, 3
+14, ntt, coeffs_0_2_3_0, coeffs_0_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_3_0, 3
+14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_0_2_3_0, coeffs_0_2_3_1, w_3_4_0, 3
+14, ntt, coeffs_0_2_3_0, coeffs_0_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_5_0, 3
+14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_0_2_3_0, coeffs_0_2_3_1, w_3_6_0, 3
+14, ntt, coeffs_0_2_3_0, coeffs_0_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_7_0, 3
+14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_0_2_3_0, coeffs_0_2_3_1, w_3_8_0, 3
+14, ntt, coeffs_0_2_3_0, coeffs_0_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_9_0, 3
+14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_0_2_3_0, coeffs_0_2_3_1, w_3_10_0, 3
+14, ntt, coeffs_0_2_3_0, coeffs_0_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_11_0, 3
+14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_0_2_3_0, coeffs_0_2_3_1, w_3_12_0, 3
+14, ntt, coeffs_0_2_3_0, coeffs_0_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_13_0, 3
 14, muli, coeffs_2_0_0, ct_2_1_0, R2_0, 0
 14, muli, coeffs_2_0_1, ct_2_1_1, R2_0, 0
 14, muli, coeffs_2_1_0, ct_2_1_0, R2_1, 1
 14, muli, coeffs_2_1_1, ct_2_1_1, R2_1, 1
 14, muli, coeffs_2_3_0, ct_2_1_0, R2_3, 3
 14, muli, coeffs_2_3_1, ct_2_1_1, R2_3, 3
-14, mul, coeffs_b_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
-14, mul, coeffs_b_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
-14, mul, coeffs_b_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
-14, mul, coeffs_b_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, w_0_0_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, w_1_0_0, 1
-14, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_1_0, 0
-14, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_1_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, w_0_2_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, w_1_2_0, 1
-14, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_3_0, 0
-14, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_3_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, w_0_4_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, w_1_4_0, 1
-14, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_5_0, 0
-14, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_5_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, w_0_6_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, w_1_6_0, 1
-14, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_7_0, 0
-14, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_7_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, w_0_8_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, w_1_8_0, 1
-14, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_9_0, 0
-14, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_9_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, w_0_10_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, w_1_10_0, 1
-14, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_11_0, 0
-14, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_11_0, 1
-14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_b_2_0_0, coeffs_b_2_0_1, w_0_12_0, 0
-14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_b_2_1_0, coeffs_b_2_1_1, w_1_12_0, 1
-14, ntt, coeffs_b_2_0_0, coeffs_b_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_13_0, 0
-14, ntt, coeffs_b_2_1_0, coeffs_b_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_13_0, 1
-14, mul, coeffs_b_2_3_0, coeffs_2_3_0, psi_0_3_0, 3
-14, mul, coeffs_b_2_3_1, coeffs_2_3_1, psi_0_3_1, 3
-14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_b_2_3_0, coeffs_b_2_3_1, w_3_0_0, 3
-14, ntt, coeffs_b_2_3_0, coeffs_b_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_1_0, 3
-14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_b_2_3_0, coeffs_b_2_3_1, w_3_2_0, 3
-14, ntt, coeffs_b_2_3_0, coeffs_b_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_3_0, 3
-14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_b_2_3_0, coeffs_b_2_3_1, w_3_4_0, 3
-14, ntt, coeffs_b_2_3_0, coeffs_b_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_5_0, 3
-14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_b_2_3_0, coeffs_b_2_3_1, w_3_6_0, 3
-14, ntt, coeffs_b_2_3_0, coeffs_b_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_7_0, 3
-14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_b_2_3_0, coeffs_b_2_3_1, w_3_8_0, 3
-14, ntt, coeffs_b_2_3_0, coeffs_b_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_9_0, 3
-14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_b_2_3_0, coeffs_b_2_3_1, w_3_10_0, 3
-14, ntt, coeffs_b_2_3_0, coeffs_b_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_11_0, 3
-14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_b_2_3_0, coeffs_b_2_3_1, w_3_12_0, 3
-14, ntt, coeffs_b_2_3_0, coeffs_b_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_13_0, 3
-14, mul, c2_rlk_0_0_0, coeffs_a_2_0_0, rlk_0_0_0_0, 0
-14, mul, c2_rlk_0_0_1, coeffs_a_2_0_1, rlk_0_0_0_1, 0
-14, mul, c2_rlk_0_1_0, coeffs_a_2_1_0, rlk_0_0_1_0, 1
-14, mul, c2_rlk_0_1_1, coeffs_a_2_1_1, rlk_0_0_1_1, 1
-14, mul, c2_rlk_1_0_0, coeffs_a_2_0_0, rlk_1_0_0_0, 0
-14, mul, c2_rlk_1_0_1, coeffs_a_2_0_1, rlk_1_0_0_1, 0
-14, mul, c2_rlk_1_1_0, coeffs_a_2_1_0, rlk_1_0_1_0, 1
-14, mul, c2_rlk_1_1_1, coeffs_a_2_1_1, rlk_1_0_1_1, 1
-14, mul, c2_rlk_0_3_0, coeffs_a_2_3_0, rlk_0_0_3_0, 3
-14, mul, c2_rlk_0_3_1, coeffs_a_2_3_1, rlk_0_0_3_1, 3
-14, mul, c2_rlk_1_3_0, coeffs_a_2_3_0, rlk_1_0_3_0, 3
-14, mul, c2_rlk_1_3_1, coeffs_a_2_3_1, rlk_1_0_3_1, 3
-14, mac, c2_rlk_0_0_0, coeffs_b_2_0_0, rlk_0_1_0_0, 0
-14, mac, c2_rlk_0_0_1, coeffs_b_2_0_1, rlk_0_1_0_1, 0
-14, mac, c2_rlk_0_1_0, coeffs_b_2_1_0, rlk_0_1_1_0, 1
-14, mac, c2_rlk_0_1_1, coeffs_b_2_1_1, rlk_0_1_1_1, 1
-14, mac, c2_rlk_1_0_0, coeffs_b_2_0_0, rlk_1_1_0_0, 0
-14, mac, c2_rlk_1_0_1, coeffs_b_2_0_1, rlk_1_1_0_1, 0
-14, mac, c2_rlk_1_1_0, coeffs_b_2_1_0, rlk_1_1_1_0, 1
-14, mac, c2_rlk_1_1_1, coeffs_b_2_1_1, rlk_1_1_1_1, 1
-14, mac, c2_rlk_0_3_0, coeffs_b_2_3_0, rlk_0_1_3_0, 3
-14, mac, c2_rlk_0_3_1, coeffs_b_2_3_1, rlk_0_1_3_1, 3
-14, mac, c2_rlk_1_3_0, coeffs_b_2_3_0, rlk_1_1_3_0, 3
-14, mac, c2_rlk_1_3_1, coeffs_b_2_3_1, rlk_1_1_3_1, 3
+14, mul, coeffs_1_2_0_0, coeffs_2_0_0, psi_0_0_0, 0
+14, mul, coeffs_1_2_1_0, coeffs_2_1_0, psi_0_1_0, 1
+14, mul, coeffs_1_2_0_1, coeffs_2_0_1, psi_0_0_1, 0
+14, mul, coeffs_1_2_1_1, coeffs_2_1_1, psi_0_1_1, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, w_0_0_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, w_1_0_0, 1
+14, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_1_0, 0
+14, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_1_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, w_0_2_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, w_1_2_0, 1
+14, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_3_0, 0
+14, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_3_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, w_0_4_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, w_1_4_0, 1
+14, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_5_0, 0
+14, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_5_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, w_0_6_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, w_1_6_0, 1
+14, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_7_0, 0
+14, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_7_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, w_0_8_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, w_1_8_0, 1
+14, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_9_0, 0
+14, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_9_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, w_0_10_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, w_1_10_0, 1
+14, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_11_0, 0
+14, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_11_0, 1
+14, ntt, outtmp_2_0_0, outtmp_2_0_1, coeffs_1_2_0_0, coeffs_1_2_0_1, w_0_12_0, 0
+14, ntt, outtmp_2_1_0, outtmp_2_1_1, coeffs_1_2_1_0, coeffs_1_2_1_1, w_1_12_0, 1
+14, ntt, coeffs_1_2_0_0, coeffs_1_2_0_1, outtmp_2_0_0, outtmp_2_0_1, w_0_13_0, 0
+14, ntt, coeffs_1_2_1_0, coeffs_1_2_1_1, outtmp_2_1_0, outtmp_2_1_1, w_1_13_0, 1
+14, mul, coeffs_1_2_3_0, coeffs_2_3_0, psi_0_3_0, 3
+14, mul, coeffs_1_2_3_1, coeffs_2_3_1, psi_0_3_1, 3
+14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_1_2_3_0, coeffs_1_2_3_1, w_3_0_0, 3
+14, ntt, coeffs_1_2_3_0, coeffs_1_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_1_0, 3
+14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_1_2_3_0, coeffs_1_2_3_1, w_3_2_0, 3
+14, ntt, coeffs_1_2_3_0, coeffs_1_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_3_0, 3
+14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_1_2_3_0, coeffs_1_2_3_1, w_3_4_0, 3
+14, ntt, coeffs_1_2_3_0, coeffs_1_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_5_0, 3
+14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_1_2_3_0, coeffs_1_2_3_1, w_3_6_0, 3
+14, ntt, coeffs_1_2_3_0, coeffs_1_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_7_0, 3
+14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_1_2_3_0, coeffs_1_2_3_1, w_3_8_0, 3
+14, ntt, coeffs_1_2_3_0, coeffs_1_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_9_0, 3
+14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_1_2_3_0, coeffs_1_2_3_1, w_3_10_0, 3
+14, ntt, coeffs_1_2_3_0, coeffs_1_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_11_0, 3
+14, ntt, outtmp_2_3_0, outtmp_2_3_1, coeffs_1_2_3_0, coeffs_1_2_3_1, w_3_12_0, 3
+14, ntt, coeffs_1_2_3_0, coeffs_1_2_3_1, outtmp_2_3_0, outtmp_2_3_1, w_3_13_0, 3
+14, mul, c2_rlk_0_0_0, coeffs_0_2_0_0, rlk_0_0_0_0, 0
+14, mul, c2_rlk_0_0_1, coeffs_0_2_0_1, rlk_0_0_0_1, 0
+14, mul, c2_rlk_0_1_0, coeffs_0_2_1_0, rlk_0_0_1_0, 1
+14, mul, c2_rlk_0_1_1, coeffs_0_2_1_1, rlk_0_0_1_1, 1
+14, mul, c2_rlk_1_0_0, coeffs_0_2_0_0, rlk_1_0_0_0, 0
+14, mul, c2_rlk_1_0_1, coeffs_0_2_0_1, rlk_1_0_0_1, 0
+14, mul, c2_rlk_1_1_0, coeffs_0_2_1_0, rlk_1_0_1_0, 1
+14, mul, c2_rlk_1_1_1, coeffs_0_2_1_1, rlk_1_0_1_1, 1
+14, mul, c2_rlk_0_3_0, coeffs_0_2_3_0, rlk_0_0_3_0, 3
+14, mul, c2_rlk_0_3_1, coeffs_0_2_3_1, rlk_0_0_3_1, 3
+14, mul, c2_rlk_1_3_0, coeffs_0_2_3_0, rlk_1_0_3_0, 3
+14, mul, c2_rlk_1_3_1, coeffs_0_2_3_1, rlk_1_0_3_1, 3
+14, mac, c2_rlk_0_0_0, coeffs_1_2_0_0, rlk_0_1_0_0, 0
+14, mac, c2_rlk_0_0_1, coeffs_1_2_0_1, rlk_0_1_0_1, 0
+14, mac, c2_rlk_0_1_0, coeffs_1_2_1_0, rlk_0_1_1_0, 1
+14, mac, c2_rlk_0_1_1, coeffs_1_2_1_1, rlk_0_1_1_1, 1
+14, mac, c2_rlk_1_0_0, coeffs_1_2_0_0, rlk_1_1_0_0, 0
+14, mac, c2_rlk_1_0_1, coeffs_1_2_0_1, rlk_1_1_0_1, 0
+14, mac, c2_rlk_1_1_0, coeffs_1_2_1_0, rlk_1_1_1_0, 1
+14, mac, c2_rlk_1_1_1, coeffs_1_2_1_1, rlk_1_1_1_1, 1
+14, mac, c2_rlk_0_3_0, coeffs_1_2_3_0, rlk_0_1_3_0, 3
+14, mac, c2_rlk_0_3_1, coeffs_1_2_3_1, rlk_0_1_3_1, 3
+14, mac, c2_rlk_1_3_0, coeffs_1_2_3_0, rlk_1_1_3_0, 3
+14, mac, c2_rlk_1_3_1, coeffs_1_2_3_1, rlk_1_1_3_1, 3
 14, intt, outtmp_0_3_0, outtmp_0_3_1, c2_rlk_0_3_0, c2_rlk_0_3_1, w_3_0_0, 3
 14, intt, y_0_3_0, y_0_3_1, outtmp_0_3_0, outtmp_0_3_1, w_3_1_0, 3
 14, intt, outtmp_0_3_0, outtmp_0_3_1, y_0_3_0, y_0_3_1, w_3_2_0, 3


### PR DESCRIPTION

## Proposed changes

PR fixes a bug which causes Kerngen to crash when RNS > 52, due to an out of bound array. The fix uses format strings instead. Updated test cases and confirmed.

## Types of changes

What types of changes does your code introduce to the Encrypted Computing SDK project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you are unsure about any of them, do not hesitate to ask. We are
here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/IntelLabs/encrypted-computing-sdk/blob/main/CONTRIBUTING.md) agreement
- [x] Current formatting and unit tests / base functionality passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

NA
